### PR TITLE
Fix config list command listing profiles

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -19,8 +19,11 @@ pub fn list(config: &DotsyConfig) {
     let configs = glob(configs_regex.to_str().unwrap()).expect("Failed to read glob pattern");
 
     println!("Available Configs to install");
-    configs.for_each(|e| {
-        println!(" - {}", e.unwrap().display());
+    configs.filter_map(Result::ok).for_each(|config| {
+        // Strip both extensions e.g. json, config from the filename before printing it
+        if let Some(file_name) = config.with_extension("").with_extension("").file_name() {
+            println!(" - {}", file_name.to_str().unwrap());
+        }
     });
     println!();
 }

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -14,12 +14,10 @@ pub fn list(config: &DotsyConfig) {
     let configs_regex = &config
         .dotfiles
         .join(&config.configs_dir)
-        .join("*.config.json")
-        .into_os_string()
-        .to_owned();
-    let configs_found =
-        glob(&configs_regex.to_str().unwrap()).expect("Failed to read glob pattern");
-    let configs = configs_found.into_iter().peekable();
+        .join("*.config.json");
+
+    let configs = glob(configs_regex.to_str().unwrap()).expect("Failed to read glob pattern");
+
     println!("Available Configs to install");
     configs.for_each(|e| {
         println!(" - {}", e.unwrap().display());

--- a/src/commands/profile.rs
+++ b/src/commands/profile.rs
@@ -18,12 +18,10 @@ pub fn list(config: &DotsyConfig) {
     let profiles_regex = &config
         .dotfiles
         .join(&config.profiles_dir)
-        .join("*.profile.json")
-        .into_os_string()
-        .to_owned();
-    let profiles_found =
-        glob(&profiles_regex.to_str().unwrap()).expect("Failed to read glob pattern");
-    let profiles = profiles_found.into_iter().peekable();
+        .join("*.profile.json");
+
+    let profiles = glob(profiles_regex.to_str().unwrap()).expect("Failed to read glob pattern");
+
     println!("Available Profiles to install");
     profiles.for_each(|e| {
         println!(" - {}", e.unwrap().display());

--- a/src/commands/profile.rs
+++ b/src/commands/profile.rs
@@ -23,8 +23,11 @@ pub fn list(config: &DotsyConfig) {
     let profiles = glob(profiles_regex.to_str().unwrap()).expect("Failed to read glob pattern");
 
     println!("Available Profiles to install");
-    profiles.for_each(|e| {
-        println!(" - {}", e.unwrap().display());
+    profiles.filter_map(Result::ok).for_each(|profile| {
+        // Strip both extensions e.g. json, profile from the filename before printing it
+        if let Some(file_name) = profile.with_extension("").with_extension("").file_name() {
+            println!(" - {}", file_name.to_str().unwrap());
+        }
     });
     println!();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ fn handle_subcommands(opt: Cli) -> DotsyResult<()> {
                     commands::config::install(opts.values, &config);
                 }
                 cli::ProfileConfigSubCommand::List => {
-                    commands::profile::list(&config);
+                    commands::config::list(&config);
                 }
             },
         }


### PR DESCRIPTION
## Changes
- Fix config list command mistakingly listing profiles 5465741ed6f2b474c7d9a206ad0e7fc3d0096516
- Update config and profile list commands to list only their respective names 98809b1723bacaf70059c45912beefcfe39f8e8f 0021524b1c72c32fc257f489b3dd5df8857fa0dd

<details>
<summary>Screenshots before and after list command changes</summary>

![Before](https://github.com/user-attachments/assets/2e7cad40-7bfa-4b4e-bb3e-05ad6c2c544f)

![After](https://github.com/user-attachments/assets/d4809116-fa4d-4c28-9b11-9c13de9d7fcb)

</details>