### PR TITLE
feat(completions): Add command to generate zsh/bash completions

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,6 +26,12 @@ pub enum ProfileConfigSubCommand {
 }
 
 #[derive(Debug, StructOpt)]
+pub enum CompletionsSubCommand {
+    Zsh,
+    Bash,
+}
+
+#[derive(Debug, StructOpt)]
 pub enum CliSubcommand {
     Profile(ProfileConfigSubCommand),
     Config(ProfileConfigSubCommand),
@@ -37,6 +43,7 @@ pub enum CliSubcommand {
         #[structopt(short = "p", long = "profile")]
         profile: Option<String>,
     },
+    Completions(CompletionsSubCommand),
 }
 
 #[derive(StructOpt, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,9 @@ use dotsy::{
     cli::{self, Cli},
     commands, dotsy_log_error, DotsyResult,
 };
+use std::io::stdout;
 use std::process;
-use structopt::StructOpt;
+use structopt::{clap::Shell, StructOpt};
 
 fn main() {
     let opt = Cli::from_args();
@@ -52,6 +53,14 @@ fn handle_subcommands(opt: Cli) -> DotsyResult<()> {
                     commands::config::list(&config);
                 }
             },
+            cli::CliSubcommand::Completions(opts) => {
+                let shell = match opts {
+                    cli::CompletionsSubCommand::Zsh => Shell::Zsh,
+                    cli::CompletionsSubCommand::Bash => Shell::Bash,
+                };
+
+                Cli::clap().gen_completions_to(env!("CARGO_PKG_NAME"), shell, &mut stdout())
+            }
         }
     }
     Ok(())


### PR DESCRIPTION
Currently only supports zsh and bash

Usage
`dotsy completions bash >> /usr/share/bash-completions/completions/dotsy.bash`
`dotsy completions zsh >> ~/.oh-my-zsh/completions/_dotsy`

Solves #12